### PR TITLE
[DoNotMerge] Providing the fm::Write trait for the DMA buffered, interrupt based UARTE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,21 @@
             "type": "cortex-debug",
             "request": "launch",
             "servertype": "jlink",
+            "name": "write (debug) jlink",
+            "preLaunchTask": "cargo build --example write",
+            "executable": "./target/thumbv7em-none-eabihf/debug/examples/write",
+            "device": "nrf52",
+            "interface": "swd",
+            "postLaunchCommands": [
+                "monitor semihosting enable",
+                "monitor semihosting ioclient 2"
+            ],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "cortex-debug",
+            "request": "launch",
+            "servertype": "jlink",
             "name": "pool (debug) jlink",
             "preLaunchTask": "cargo build --example pool",
             "executable": "./target/thumbv7em-none-eabihf/debug/examples/pool",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,21 @@
             "type": "cortex-debug",
             "request": "launch",
             "servertype": "jlink",
+            "name": "pool (debug) jlink",
+            "preLaunchTask": "cargo build --example pool",
+            "executable": "./target/thumbv7em-none-eabihf/debug/examples/pool",
+            "device": "nrf52",
+            "interface": "swd",
+            "postLaunchCommands": [
+                "monitor semihosting enable",
+                "monitor semihosting ioclient 2"
+            ],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "cortex-debug",
+            "request": "launch",
+            "servertype": "jlink",
             "name": "app (debug) jlink",
             "preLaunchTask": "cargo build --example app",
             "executable": "./target/thumbv7em-none-eabihf/debug/examples/app",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,6 +53,18 @@
         },
         {
             "type": "shell",
+            "label": "cargo build --example write",
+            "command": "cargo build --example write",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "shell",
             "label": "cargo build --example pool",
             "command": "cargo build --example pool",
             "problemMatcher": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -53,6 +53,18 @@
         },
         {
             "type": "shell",
+            "label": "cargo build --example pool",
+            "command": "cargo build --example pool",
+            "problemMatcher": [
+                "$rustc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "shell",
             "label": "cargo build --example app",
             "command": "cargo build --example app",
             "problemMatcher": [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ embedded-hal            = "0.2.2"
 
 [dependencies.heapless]
 version                 = "0.4.3"
-features                = ["min-const-fn"]
+features                = ["const-fn"]
 
 [dependencies.dwm1001]
 version                 = "0.2.0"
@@ -24,7 +24,7 @@ features                = ["dev", "rt"]
 [dependencies.cortex-m-rtfm]
 version                 = "0.4.3"
 features                = [
-#    "nightly",
+ #   "nightly",
     "timer-queue"
     ] # disable if not using timed messages
 

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,0 +1,118 @@
+#![no_main]
+#![no_std]
+
+// panic handler
+extern crate panic_semihosting;
+
+use cortex_m_semihosting::hprintln;
+use dwm1001::{new_usb_uarte, nrf52832_hal as hal, UsbUarteConfig};
+
+use hal::prelude::*;
+use hal::target::{interrupt, UARTE0};
+use hal::{DMAPool, RXError, TXQSize, UarteRX, UarteTX, DMA_SIZE};
+
+use core::fmt::Write;
+
+use heapless::{
+    // consts::*,
+    // pool,
+    pool::singleton::{Box, Pool},
+    spsc::{Queue},
+};
+
+use rtfm::app;
+
+const NR_PACKAGES: usize = 10;
+const DMA_MEM: usize = DMA_SIZE * NR_PACKAGES + 16;
+
+const PERIOD: u32 = 64_000_000;
+
+#[app(device = crate::hal::target)]
+const APP: () = {
+    static mut RX: UarteRX<UARTE0> = ();
+    static mut TX: UarteTX<UARTE0> = ();
+    //static mut PRODUCER: Producer<'static, Box<DMAPool>, TXQSize> = ();
+
+    #[init(spawn = [write_test])]
+    fn init() -> init::LateResources {
+        // for the actual DMA buffers
+        static mut MEMORY: [u8; DMA_MEM] = [0; DMA_MEM];
+        // for the producer/consumer of TX
+        static mut TX_RB: Option<Queue<(Box<DMAPool>,usize), TXQSize>> = None;
+
+        hprintln!("init").unwrap();
+        // move MEMORY to P (the DMA buffer allocator)
+        DMAPool::grow(MEMORY);
+
+        let port0 = device.P0.split();
+        let uarte0 = new_usb_uarte(
+            device.UARTE0,             // the actual UART
+            port0.p0_05,               // txd
+            port0.p0_11,               // rxd
+            UsbUarteConfig::default(), // 115200
+        );
+
+        *TX_RB = Some(Queue::new());
+        let (txp, txc) = TX_RB.as_mut().unwrap().split();
+        let (rx, tx) = uarte0.split(Queue::new(), txc, txp);
+
+        spawn.write_test().unwrap();
+
+        init::LateResources {
+            RX: rx,
+            TX: tx,
+            //PRODUCER: txp,
+        }
+    }
+
+    #[task(schedule=[write_test], resources=[TX])]
+    fn write_test() {
+      resources.TX.lock(|tx|{
+        writeln!(*tx, "Hello write trait\r").unwrap();
+      });
+      schedule.write_test(scheduled + PERIOD.cycles()).unwrap();
+    }
+
+    // // we can get Box<P> us being now the owner
+    #[task(capacity = 2, resources = [TX])]
+    fn printer(data: Box<DMAPool>) {
+        // enqueue a test message
+        // let mut b = DMAPool::alloc().unwrap().freeze();
+        // b.copy_from_slice(&[0, 1, 2, 3]);
+
+        // hprintln!("{:?}", &data).unwrap();
+        // just do the buffer dance without copying
+        resources.TX.lock(|tx|{
+          let len = data.len();
+          tx.enqueue((data, len));
+        });
+        rtfm::pend(interrupt::UARTE0_UART0);
+    }
+
+    #[task]
+    fn rx_error(err: RXError) {
+        hprintln!("rx_error {:?}", err).unwrap();
+    }
+
+    #[interrupt(priority = 2, resources = [RX, TX], spawn = [printer,rx_error])]
+    fn UARTE0_UART0() {
+        // probe RX
+        match resources.RX.process_interrupt() {
+            Ok(Some(b)) => {
+              match spawn.printer(b) {
+                  Err(_) => spawn.rx_error(RXError::OOM).unwrap(),
+                  _ => (),
+              };
+            }
+            Ok(None) => (), // no
+            Err(err) => spawn.rx_error(err).unwrap(),
+        }
+
+        resources.TX.process_interrupt();
+    }
+
+    extern "C" {
+        fn SWI1_EGU1();
+        fn SWI2_EGU2();
+    }
+};

--- a/nrf52-hal/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal/nrf52-hal-common/Cargo.toml
@@ -24,7 +24,7 @@ rand_core = "0.4.0"
 
 [dependencies.heapless]
 version                 = "0.4.3"
-features                = ["min-const-fn"]
+features                = ["const-fn"]
 
 [dependencies.void]
 default-features = false

--- a/nrf52-hal/nrf52-hal-common/Cargo.toml
+++ b/nrf52-hal/nrf52-hal-common/Cargo.toml
@@ -24,14 +24,8 @@ rand_core = "0.4.0"
 
 [dependencies.heapless]
 version                 = "0.4.3"
-<<<<<<< HEAD
-features                = ["const-fn"]
-||||||| merged common ancestors
-features                = ["min-const-fn"]
-=======
 #features                = ["min-const-fn"]
 features                = ["const-fn"]
->>>>>>> 7a153023d4c7923e058126ae6bd12f9ce7639098
 
 [dependencies.void]
 default-features = false


### PR DESCRIPTION
This is my current take on providing some form of `fmt::Write` trait implementation for the DMA buffered and interrupt based UARTE. Currently it requires the `UarteTX` type to have ownership of the `Producer`, but to mitigate the effects, reexports the `enqueue` method so `UarteTX` can be used instead of the `Producer`. Far from the perfect, but seems to work so far.

Question: It would be nice to have some kind of "Device under Test"-Framework, which allows me to run tests on the device, but also to validate communication with the host. This would allow me to write a test which checks that I receive certain data via serial on the host and can echo data, while I iterate on the actual fmt::Write implementation. I couldn't find anything for rust. Are you aware of anything like that?